### PR TITLE
fix: error when Neovim terminal is set to a non interactive mode

### DIFF
--- a/lua/conda/envs.lua
+++ b/lua/conda/envs.lua
@@ -1,5 +1,6 @@
 local utils = require("conda.utils")
 local set = require("conda.functional.set")
+local string_ = require("conda.functional.string")
 local envs = {}
 
 ---@param env_name string, name of an existing conda environment
@@ -17,7 +18,8 @@ function envs.activate(env_name, conda_envs)
 		print("The current shell is not supported by conda")
 		return nil
 	end
-	local vim_conda_activate_command = (vim.fn.system(activator_command))
+	local _vim_conda_activate_command = (vim.fn.system(activator_command))
+	local vim_conda_activate_command = string_.clean_vim_activator(_vim_conda_activate_command)
 	vim.cmd(vim_conda_activate_command)
 end
 
@@ -29,7 +31,8 @@ function envs.deactivate()
 		print("The current shell is not supported by conda")
 		return nil
 	end
-	local vim_conda_deactivate_command = (vim.fn.system(activator_command))
+	local _vim_conda_deactivate_command = (vim.fn.system(activator_command))
+	local vim_conda_deactivate_command = string_.clean_vim_activator(_vim_conda_deactivate_command)
 	vim.cmd(vim_conda_deactivate_command)
 end
 

--- a/lua/conda/functional/string.lua
+++ b/lua/conda/functional/string.lua
@@ -1,0 +1,16 @@
+local M = {}
+
+---@param shell_output string
+---@return string
+M.clean_vim_activator = function(shell_output)
+	-- clean output in case Neovim is set to a non interactive mode
+	local clean_output = {}
+	for line in shell_output:gmatch("[^\r\n]+") do
+		if string.match(line, "^(let)") or string.match(line, "^(unlet)") then
+			table.insert(clean_output, line)
+		end
+	end
+	return table.concat(clean_output, "\n")
+end
+
+return M


### PR DESCRIPTION
Apply RegEx to eliminate shell output that it not part of the environment variables assignment