### PR TITLE
Fixed compatibility with Nvim 0.11 LSP API changes

### DIFF
--- a/lua/conda/lsps/lspconfig.lua
+++ b/lua/conda/lsps/lspconfig.lua
@@ -2,7 +2,8 @@ local M = {}
 
 ---@return nil
 M.restart_lsps = function()
-  vim.api.nvim_command("LspRestart")
+  vim.api.nvim_command("LspRestart pyright")
+  vim.api.nvim_command("LspRestart basedpyright")
 end
 
 return M


### PR DESCRIPTION
Latest Nvim version (0.11) did some changes to the API, and now the 'config_name/client_id' argument  in 'LspRestart' is not optional.

My solution is very ad-hoc, making use of the fact that LspRestart fails silently when inputting a valid name (see [this list](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md)) even when not active or even installed. I restart pyright and basedpyright as those are the lsps that I used for python.

I tried enumerating all lsps and restart them if they react to python files, but then other lsp plugins like null-ls don't work nicely with LspRestart.

If someone knows how to list all LspConfig LSPs, that would improve the solution greatly (and I would be very grateful!), but I think this is an acceptable solution for now.